### PR TITLE
Use the correct library in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Sample Performance Tests - Banking (Using [JUnit](https://github.com/junit-team/
 ```xml
 <dependency>
     <groupId>org.jsmart</groupId>
-    <artifactId>zerocode-tdd</artifactId>
+    <artifactId>zerocode-rest-bdd</artifactId>
     <version>1.2.x</version> 
 </dependency>
 ```


### PR DESCRIPTION
The library in this demo itself uses `zerocode-rest-bdd` instead of    `zerocode-tdd`.